### PR TITLE
feat: Update elapsed and moving time types to float

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2906,7 +2906,8 @@
         },
         "elapsed_time": {
           "description": "The total elapsed time of the considered activities.",
-          "type": "integer"
+          "type": "number",
+          "format": "float"
         },
         "elevation_gain": {
           "description": "The total elevation gain of the considered activities.",
@@ -2915,7 +2916,8 @@
         },
         "moving_time": {
           "description": "The total moving time of the considered activities.",
-          "type": "integer"
+          "type": "number",
+          "format": "float"
         }
       }
     },

--- a/internal/gen/strava-api-go/models/activity_total.go
+++ b/internal/gen/strava-api-go/models/activity_total.go
@@ -24,13 +24,13 @@ type ActivityTotal struct {
 	Distance float32 `json:"distance,omitempty"`
 
 	// The total elapsed time of the considered activities.
-	ElapsedTime int64 `json:"elapsed_time,omitempty"`
+	ElapsedTime float32 `json:"elapsed_time,omitempty"`
 
 	// The total elevation gain of the considered activities.
 	ElevationGain float32 `json:"elevation_gain,omitempty"`
 
 	// The total moving time of the considered activities.
-	MovingTime int64 `json:"moving_time,omitempty"`
+	MovingTime float32 `json:"moving_time,omitempty"`
 }
 
 // Validate validates this activity total


### PR DESCRIPTION
These values, representing time, can contain fractions of seconds and are better represented as floating-point numbers. This change updates both the OpenAPI specification and the generated Go model for improved precision.